### PR TITLE
fosite oauth2: Update TokenRevocationStorage to use Requester

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -519,9 +519,9 @@ is an example of how to do that using only existing methods:
 func (s *MemoryStore) PersistRefreshTokenGrantSession(ctx context.Context, originalRefreshSignature, accessSignature, refreshSignature string, request fosite.Requester) error {
 	if ts, err := s.GetRefreshTokenSession(ctx, originalRefreshSignature, nil); err != nil {
 		return err
-	} else if err := s.RevokeAccessToken(ctx, ts.GetID()); err != nil {
+	} else if err := s.RevokeAccessToken(ctx, ts); err != nil {
 		return err
-	} else if err := s.RevokeRefreshToken(ctx, ts.GetID()); err != nil {
+	} else if err := s.RevokeRefreshToken(ctx, ts); err != nil {
  		return err
  	} else if err := s.CreateAccessTokenSession(ctx, accessSignature, request); err != nil {
  		return err

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -56,14 +56,13 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 		}
 
 		//If an authorize code is used twice, we revoke all refresh and access tokens associated with this request.
-		reqID := authorizeRequest.GetID()
 		hint := "The authorization code has already been used."
 		debug := ""
-		if revErr := c.TokenRevocationStorage.RevokeAccessToken(ctx, reqID); revErr != nil {
+		if revErr := c.TokenRevocationStorage.RevokeAccessToken(ctx, authorizeRequest); revErr != nil {
 			hint += " Additionally, an error occurred during processing the access token revocation."
 			debug += "Revokation of access_token lead to error " + revErr.Error() + "."
 		}
-		if revErr := c.TokenRevocationStorage.RevokeRefreshToken(ctx, reqID); revErr != nil {
+		if revErr := c.TokenRevocationStorage.RevokeRefreshToken(ctx, authorizeRequest); revErr != nil {
 			hint += " Additionally, an error occurred during processing the refresh token revocation."
 			debug += "Revokation of refresh_token lead to error " + revErr.Error() + "."
 		}

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -143,12 +143,12 @@ func (c *RefreshTokenGrantHandler) PopulateTokenEndpointResponse(ctx context.Con
 			err = rollBackTxnErr
 		}
 		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
-	} else if err := c.TokenRevocationStorage.RevokeAccessToken(ctx, ts.GetID()); err != nil {
+	} else if err := c.TokenRevocationStorage.RevokeAccessToken(ctx, ts); err != nil {
 		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
 			err = rollBackTxnErr
 		}
 		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
-	} else if err := c.TokenRevocationStorage.RevokeRefreshToken(ctx, ts.GetID()); err != nil {
+	} else if err := c.TokenRevocationStorage.RevokeRefreshToken(ctx, ts); err != nil {
 		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
 			err = rollBackTxnErr
 		}

--- a/handler/oauth2/revocation.go
+++ b/handler/oauth2/revocation.go
@@ -69,9 +69,8 @@ func (r *TokenRevocationHandler) RevokeToken(ctx context.Context, token string, 
 		return errors.WithStack(fosite.ErrRevokationClientMismatch)
 	}
 
-	requestID := ar.GetID()
-	r.TokenRevocationStorage.RevokeRefreshToken(ctx, requestID)
-	r.TokenRevocationStorage.RevokeAccessToken(ctx, requestID)
+	r.TokenRevocationStorage.RevokeRefreshToken(ctx, ar)
+	r.TokenRevocationStorage.RevokeAccessToken(ctx, ar)
 
 	return nil
 }

--- a/handler/oauth2/revocation_storage.go
+++ b/handler/oauth2/revocation_storage.go
@@ -23,6 +23,8 @@ package oauth2
 
 import (
 	"context"
+
+	"github.com/ory/fosite"
 )
 
 // TokenRevocationStorage provides the storage implementation
@@ -38,12 +40,12 @@ type TokenRevocationStorage interface {
 	// revocation of access tokens, then the authorization server SHOULD
 	// also invalidate all access tokens based on the same authorization
 	// grant (see Implementation Note).
-	RevokeRefreshToken(ctx context.Context, requestID string) error
+	RevokeRefreshToken(ctx context.Context, ar fosite.Requester) error
 
 	// RevokeAccessToken revokes an access token as specified in:
 	// https://tools.ietf.org/html/rfc7009#section-2.1
 	// If the token passed to the request
 	// is an access token, the server MAY revoke the respective refresh
 	// token as well.
-	RevokeAccessToken(ctx context.Context, requestID string) error
+	RevokeAccessToken(ctx context.Context, ar fosite.Requester) error
 }

--- a/internal/oauth2_revoke_storage.go
+++ b/internal/oauth2_revoke_storage.go
@@ -111,7 +111,7 @@ func (mr *MockTokenRevocationStorageMockRecorder) GetRefreshTokenSession(arg0, a
 }
 
 // RevokeAccessToken mocks base method
-func (m *MockTokenRevocationStorage) RevokeAccessToken(arg0 context.Context, arg1 string) error {
+func (m *MockTokenRevocationStorage) RevokeAccessToken(arg0 context.Context, arg1 fosite.Requester) error {
 	ret := m.ctrl.Call(m, "RevokeAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -123,7 +123,7 @@ func (mr *MockTokenRevocationStorageMockRecorder) RevokeAccessToken(arg0, arg1 i
 }
 
 // RevokeRefreshToken mocks base method
-func (m *MockTokenRevocationStorage) RevokeRefreshToken(arg0 context.Context, arg1 string) error {
+func (m *MockTokenRevocationStorage) RevokeRefreshToken(arg0 context.Context, arg1 fosite.Requester) error {
 	ret := m.ctrl.Call(m, "RevokeRefreshToken", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -237,16 +237,16 @@ func (s *MemoryStore) Authenticate(_ context.Context, name string, secret string
 	return nil
 }
 
-func (s *MemoryStore) RevokeRefreshToken(ctx context.Context, requestID string) error {
-	if signature, exists := s.RefreshTokenRequestIDs[requestID]; exists {
+func (s *MemoryStore) RevokeRefreshToken(ctx context.Context, req fosite.Requester) error {
+	if signature, exists := s.RefreshTokenRequestIDs[req.GetID()]; exists {
 		s.DeleteRefreshTokenSession(ctx, signature)
 		s.DeleteAccessTokenSession(ctx, signature)
 	}
 	return nil
 }
 
-func (s *MemoryStore) RevokeAccessToken(ctx context.Context, requestID string) error {
-	if signature, exists := s.AccessTokenRequestIDs[requestID]; exists {
+func (s *MemoryStore) RevokeAccessToken(ctx context.Context, req fosite.Requester) error {
+	if signature, exists := s.AccessTokenRequestIDs[req.GetID()]; exists {
 		s.DeleteAccessTokenSession(ctx, signature)
 	}
 	return nil


### PR DESCRIPTION
Updating the TokenRevocationStorage interface to accept a
fosite.Requester object rather than a requestId, since we need to get
access to the session object for the orgId in order to access the
sharded storage tables.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [ ] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
